### PR TITLE
feat: provide natural language ai diagnosis, exercise recommendation and modular service apis

### DIFF
--- a/app/ai_coach_router.py
+++ b/app/ai_coach_router.py
@@ -1,43 +1,49 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-import requests
-import json
 import redis
+import os
+from dotenv import load_dotenv
+from app.services.ai_coach_service import ai_coach_interaction_service
+from app.analyze_router import llm  # 글로벌 llm 인스턴스 재사용
+import json
 
-redis_client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+load_dotenv()
+redis_client = redis.Redis(host=os.getenv("REDIS_HOST", "localhost"), port=6379, db=0, decode_responses=True)
 
 router = APIRouter(prefix="/ai-coach", tags=["AI Coach"])
 
-class CoachRequest(BaseModel):
+class AiCoachRequest(BaseModel):
     userId: int
-    historyId: int
-    message: str = None
-    diagnosis: dict = None  # Spring에서 진단 결과를 직접 전달받음
-    recommended_exercise: dict = None  # Spring에서 추천운동을 직접 전달받음
+    diagnosis: dict  # {"korean": ...}
+    recommended_exercise: dict  # {"name": ...}
+    message: str = None  # 사용자의 추가 메시지(선택)
 
-class CoachResponse(BaseModel):
+class AiCoachResponse(BaseModel):
     type: str
     response: str
+    history: list = None
 
-@router.post("", response_model=CoachResponse)
-async def ai_coach_endpoint(req: CoachRequest):
-    session_key = f"chat_session:{req.userId}"
-    # SPRING_API_URL 삭제
-    # 진단/추천운동 등은 req에서 직접 받음
-    diagnosis = req.diagnosis or {"korean": "진단 정보가 없습니다."}
-    recommended_exercise = req.recommended_exercise or {"name": "목 스트레칭"}
-    state = {
-        "diagnosis": diagnosis,
-        "recommended_exercise": recommended_exercise,
-        "user_message": req.message
-    }
-    from app.analyze_router import recommend_exercise_node
-    from app.main_graph import ai_coach_interaction_node
-    # recommend_exercise_node는 analyze_router에서 import
-    # 이미 추천운동이 있으면 recommend_exercise_node는 생략 가능
-    result = ai_coach_interaction_node(state)
-    if "error" in result:
-        return CoachResponse(type="error", response=f"AI 코치 오류: {result['error']}")
-    response_text = result["messages"][-1].content if "messages" in result and result["messages"] else "AI 코치 응답이 없습니다."
-    redis_client.rpush(session_key, json.dumps({"type": "ai_coach", "content": response_text}))
-    return CoachResponse(type="ai_coach", response=response_text) 
+@router.post("", response_model=AiCoachResponse)
+async def ai_coach_endpoint(req: AiCoachRequest):
+    session_key = f"ai_coach_session:{req.userId}"
+    # Redis에서 기존 대화 내역 불러오기 (없으면 빈 리스트)
+    history = []
+    if redis_client.exists(session_key):
+        try:
+            history = json.loads(redis_client.get(session_key))
+        except Exception:
+            history = []
+    # 사용자의 메시지가 있으면 대화 내역에 추가
+    if req.message:
+        history.append({"role": "user", "content": req.message})
+    # AI 코치 응답 생성
+    diagnosis_text = req.diagnosis.get("korean", "")
+    ai_coach_result = ai_coach_interaction_service(diagnosis_text, req.recommended_exercise, llm)
+    if "error" in ai_coach_result:
+        raise HTTPException(status_code=500, detail=ai_coach_result["error"])
+    ai_coach_message = ai_coach_result["ai_coach_response"]
+    # 대화 내역에 AI 코치 응답 추가
+    history.append({"role": "ai_coach", "content": ai_coach_message})
+    # Redis에 24시간 TTL로 저장 (세션 1개만 유지)
+    redis_client.set(session_key, json.dumps(history), ex=60*60*24)
+    return AiCoachResponse(type="ai_coach", response=ai_coach_message, history=history) 

--- a/app/analyze_router.py
+++ b/app/analyze_router.py
@@ -10,11 +10,15 @@ import redis
 from app.services.posture_analyzer import PostureAnalyzer
 from app.services.exercise_vector_db import ExerciseVectorDB
 from app.services.radar_chart import plot_radar_chart
+from app.services.exercise_vector_db import ExerciseVectorDB
+from app.services.recommend_exercise_service import recommend_exercise_node
+from langchain_openai import ChatOpenAI
 import cloudinary
 import cloudinary.uploader
 import uuid
 import tempfile
 import shutil
+
 
 load_dotenv()
 
@@ -26,24 +30,26 @@ cloudinary.config(
 redis_client = redis.Redis(host=os.getenv("REDIS_HOST", "localhost"), port=6379, db=0, decode_responses=True)
 posture_analyzer = PostureAnalyzer(model_path="models/yolopose_v1.pt")
 vector_db = ExerciseVectorDB()
-
 router = APIRouter()
+llm = ChatOpenAI(model="gpt-4o-mini")
+vector_db = ExerciseVectorDB()
 
-def download_image_to_tempfile(image_url: str) -> str:
-    response = requests.get(image_url, stream=True)
-    if response.status_code == 200:
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-        with open(tmp.name, 'wb') as out_file:
-            shutil.copyfileobj(response.raw, out_file)
-        return tmp.name
-    else:
-        raise Exception(f"이미지 다운로드 실패: {image_url}")
-
+# --- FastAPI 요청 바디 데이터 모델 정의 ---
 class AnalysisRequest(BaseModel):
+    """
+    단일 이미지 분석 요청에 사용되는 데이터 모델.
+    - image_url: Cloudinary 이미지 URL
+    - analysis_mode: 분석 모드 ('front' 또는 'side'), 기본값 'front'
+    """
     image_url: str
     analysis_mode: str = "front"
 
 class MultiAnalysisRequest(BaseModel):
+    """
+    정면+측면 MERGE 분석 요청에 사용되는 데이터 모델.
+    - front_image_url: 정면 Cloudinary 이미지 URL
+    - side_image_url: 측면 Cloudinary 이미지 URL
+    """
     front_image_url: str
     side_image_url: str
 
@@ -52,18 +58,10 @@ class MultiAnalysisRequest(BaseModel):
 async def analyze_graph_endpoint(request: AnalysisRequest):
     print("=== [분석 요청] ===")
     print("request:", request)
-    # Cloudinary가 아닌 경우 로컬로 다운로드 후 업로드
+    # Cloudinary URL만 허용
     image_url = request.image_url
-    local_path = None
     if not image_url.startswith("https://res.cloudinary.com/"):
-        local_path = download_image_to_tempfile(image_url)
-        # Cloudinary 업로드
-        try:
-            upload_result = cloudinary.uploader.upload(local_path)
-            image_url = upload_result["secure_url"]
-        finally:
-            if os.path.exists(local_path):
-                os.remove(local_path)
+        raise HTTPException(status_code=400, detail="Cloudinary 이미지 URL만 허용됩니다.")
     analysis_result = posture_analyzer.analyze_posture(image_url, mode=request.analysis_mode)
     print("analysis_result:", analysis_result)
     if not analysis_result.get("success"):
@@ -73,10 +71,12 @@ async def analyze_graph_endpoint(request: AnalysisRequest):
     print("pose_data:", pose_data)
     diagnosis = posture_analyzer.generate_ollama_diagnosis(pose_data, request.analysis_mode)
     print("diagnosis:", diagnosis)
-    search_query = f"{request.analysis_mode} 자세 교정 운동"
-    recommended_list = vector_db.search(search_query, top_k=1)
-    recommended_exercise = recommended_list[0] if recommended_list else {}
-    print("recommended_exercise:", recommended_exercise)
+    # 추천운동 생성
+    rec_result = recommend_exercise_node(diagnosis.get("korean", ""), vector_db, llm)
+    if "error" in rec_result:
+        raise HTTPException(status_code=500, detail=rec_result["error"])
+    recommended_exercise = rec_result.get("recommended_exercise", {})
+    search_query = rec_result.get("search_query", "")
 
     # 점수 dict 동적 생성 (정면/측면 여부에 따라)
     scores = pose_data.get('scores', {}) if pose_data else {}
@@ -124,9 +124,10 @@ async def analyze_graph_endpoint(request: AnalysisRequest):
     print("최종 응답 radar_chart_url:", radar_chart_url)
     return {
         "diagnosis": diagnosis,
+        "recommended_exercise": recommended_exercise,
+        "search_query": search_query,
         "pose_data": pose_data,
         "radar_chart_url": radar_chart_url,
-        "recommended_exercise": recommended_exercise,
         "spineCurvScore": scores.get("척추굽음score", 0),
         "spineScolScore": scores.get("척추휨score", 0),
         "pelvicScore": scores.get("골반틀어짐score", 0),
@@ -136,41 +137,50 @@ async def analyze_graph_endpoint(request: AnalysisRequest):
 
 @router.post("/analyze-graph/merge")
 async def analyze_graph_merge_endpoint(request: MultiAnalysisRequest):
-    # 정면
     front_url = request.front_image_url
-    front_local = None
-    if not front_url.startswith("https://res.cloudinary.com/"):
-        front_local = download_image_to_tempfile(front_url)
-        try:
-            upload_result = cloudinary.uploader.upload(front_local)
-            front_url = upload_result["secure_url"]
-        finally:
-            if os.path.exists(front_local):
-                os.remove(front_local)
-    # 측면
     side_url = request.side_image_url
-    side_local = None
-    if not side_url.startswith("https://res.cloudinary.com/"):
-        side_local = download_image_to_tempfile(side_url)
-        try:
-            upload_result = cloudinary.uploader.upload(side_local)
-            side_url = upload_result["secure_url"]
-        finally:
-            if os.path.exists(side_local):
-                os.remove(side_local)
+    if not front_url.startswith("https://res.cloudinary.com/") or not side_url.startswith("https://res.cloudinary.com/"):
+        raise HTTPException(status_code=400, detail="Cloudinary 이미지 URL만 허용됩니다.")
     # 분석
     front_result = posture_analyzer.analyze_posture(front_url, mode='front')
     front_pose = front_result.get('pose_data', [{}])[0] if front_result.get('pose_data') else {}
     side_result = posture_analyzer.analyze_posture(side_url, mode='side')
     side_pose = side_result.get('pose_data', [{}])[0] if side_result.get('pose_data') else {}
-    # measurements 로그 추가
     print("[merge] front_pose measurements:", front_pose.get('measurements'))
     print("[merge] side_pose measurements:", side_pose.get('measurements'))
-    # diagnosis 생성 (front, side 모두)
-    diagnosis = {
-        "front": posture_analyzer.generate_ollama_diagnosis(front_pose, "front"),
-        "side": posture_analyzer.generate_ollama_diagnosis(side_pose, "side")
+
+    # 5개 부위 점수 합치기
+    front_scores = front_pose.get('scores', {}) if front_pose else {}
+    side_scores = side_pose.get('scores', {}) if side_pose else {}
+    all_scores = {
+        "어깨score": front_scores.get("어깨score"),
+        "골반틀어짐score": front_scores.get("골반틀어짐score"),
+        "척추휨score": front_scores.get("척추휨score"),
+        "척추굽음score": side_scores.get("척추굽음score"),
+        "거북목score": side_scores.get("거북목score"),
     }
+    # 가장 낮은 점수와 해당 부위 찾기
+    min_part = None
+    min_score = 101
+    for key, val in all_scores.items():
+        if val is not None and val < min_score:
+            min_score = val
+            min_part = key
+    # 해당 부위의 pose_data 선택 (front/side)
+    if min_part in ["어깨score", "골반틀어짐score", "척추휨score"]:
+        pose_data_for_diag = front_pose
+    else:
+        pose_data_for_diag = side_pose
+    # 진단 생성 (5개 부위 중 가장 낮은 점수만 기반)
+    diagnosis = posture_analyzer.generate_ollama_diagnosis(pose_data_for_diag, "merge")
+
+    # 추천운동 생성
+    rec_result = recommend_exercise_node(diagnosis.get("korean", ""), vector_db, llm)
+    if "error" in rec_result:
+        raise HTTPException(status_code=500, detail=rec_result["error"])
+    recommended_exercise = rec_result.get("recommended_exercise", {})
+    search_query = rec_result.get("search_query", "")
+
     front_scores = front_pose.get('scores', {}) if front_pose else {}
     side_scores = side_pose.get('scores', {}) if side_pose else {}
     radar_scores = {
@@ -194,6 +204,8 @@ async def analyze_graph_merge_endpoint(request: MultiAnalysisRequest):
                 os.remove(radar_chart_path)
     return {
         "diagnosis": diagnosis,
+        "recommended_exercise": recommended_exercise,
+        "search_query": search_query,
         "radar_scores": radar_scores,
         "radar_chart_url": radar_chart_url,
         "front_pose_data": front_pose,
@@ -204,34 +216,3 @@ async def analyze_graph_merge_endpoint(request: MultiAnalysisRequest):
         "neckScore": side_scores.get("거북목score", 0),
         "shoulderScore": front_scores.get("어깨score", 0)
     }
-
-    # (recommend_exercise_node 함수 추가)
-def recommend_exercise_node(state):
-    print("[Node 2] 맞춤 운동 추천 중 (from VectorDB)...")
-    if state.get("error"): return {}
-    try:
-        diagnosis_text = state["diagnosis"]["korean"]
-        from app.services.exercise_vector_db import ExerciseVectorDB
-        from langchain_openai import ChatOpenAI
-        llm = ChatOpenAI(model="gpt-4o-mini")
-        vector_db = ExerciseVectorDB()
-        prompt = f"""아래의 자세 진단 내용에 가장 적합한 '단 한 가지'의 검색어을 추천해줘. 
-        ~난이도, ~효과를 가진, ~부위의, ~운동의 순서로 검색어를 작성해야해.
-        VectorDB 검색에 사용할 키워드 문장 오직 한개만 간결하게 한 줄로 답해줘.
-        
-        [진단 내용]
-        {diagnosis_text}
-        [출력 예시]
-        - 중급 난이도의 유연성을 높이는 효과를 가진 골반 부위의 스트레칭 운동
-        [생성된 검색어]
-        """
-        llm_query = llm.invoke(prompt).content.strip()
-        print(f"  > LLM 생성 검색어: '{llm_query}'")
-        recommended_list = vector_db.search(llm_query, top_k=1)
-        if not recommended_list:
-            raise ValueError("VectorDB에서 추천 운동을 찾지 못했습니다.")
-        retrieved_exercise = recommended_list[0]
-        print(f"  > VectorDB 검색 결과 운동명: '{retrieved_exercise['name']}'")
-        return {"recommended_exercise": retrieved_exercise, "search_query": llm_query}
-    except Exception as e:
-        return {"error": f"운동 추천 노드 오류: {e}"}

--- a/app/services/ai_coach_service.py
+++ b/app/services/ai_coach_service.py
@@ -1,0 +1,28 @@
+def ai_coach_interaction_service(diagnosis_text: str, recommended_exercise: dict, llm) -> dict:
+    """
+    AI 코치와의 대화(상담/동기부여) 메시지를 생성하는 서비스 함수.
+    Args:
+        diagnosis_text (str): 한글 진단 내용
+        recommended_exercise (dict): 추천 운동 객체 (예: {'name': '스쿼트', ...})
+        llm: LLM 인스턴스 (예: langchain_openai.ChatOpenAI)
+    Returns:
+        dict: { 'ai_coach_response': str }
+    """
+    print("[AICoachService] AI 코치 상담 메시지 생성 중...")
+    try:
+        exercise_name = recommended_exercise.get('name', '운동')
+        prompt = f"""
+        당신은 AI 피트니스 코치입니다. 아래 정보를 바탕으로 사용자에게 동기부여와 상담 메시지를 생성하세요.
+        [진단 내용]
+        {diagnosis_text}
+        [추천 운동]
+        {exercise_name}
+        사용자에게 운동의 중요성과 자세 교정의 필요성을 설명하고, 긍정적이고 격려하는 어조로 동기부여를 제공하세요.
+        반드시 한국어로 2~3문장으로 답변하세요.
+        """
+        response = llm.invoke(prompt).content.strip()
+        print(f"  > AI 코치 응답: {response}")
+        return {"ai_coach_response": response}
+    except Exception as e:
+        print(f"[AICoachService] 오류: {e}")
+        return {"error": f"AI 코치 서비스 오류: {e}"} 

--- a/app/services/recommend_exercise_service.py
+++ b/app/services/recommend_exercise_service.py
@@ -1,0 +1,34 @@
+def recommend_exercise_node(diagnosis_text: str, vector_db, llm) -> dict:
+    """
+    진단 내용을 바탕으로 LLM을 통해 운동 추천 검색어를 생성하고, VectorDB에서 추천 운동을 반환합니다.
+    Args:
+        diagnosis_text (str): 한글 진단 내용
+        vector_db: 운동 벡터 DB 인스턴스
+        llm: LLM 인스턴스 (예: langchain_openai.ChatOpenAI)
+    Returns:
+        dict: { 'recommended_exercise': 운동 객체, 'search_query': 생성된 검색어 }
+    """
+    print("[RecommendExerciseService] 맞춤 운동 추천 중 (from VectorDB)...")
+    try:
+        # LLM을 사용해 진단 내용에서 핵심 키워드를 추출하여 검색 쿼리 생성
+        prompt = f"""아래의 자세 진단 내용에 가장 적합한 '단 한 가지'의 검색어을 추천해줘. 
+        ~난이도, ~효과를 가진, ~부위의, ~운동의 순서로 검색어를 작성해야해.
+        VectorDB 검색에 사용할 키워드 문장 오직 한개만 간결하게 한 줄로 답해줘.
+        
+        [진단 내용]
+        {diagnosis_text}
+        [출력 예시]
+        - 중급 난이도의 유연성을 높이는 효과를 가진 골반 부위의 스트레칭 운동
+        [생성된 검색어]
+        """
+        llm_query = llm.invoke(prompt).content.strip()
+        print(f"  > LLM 생성 검색어: '{llm_query}'")
+        recommended_list = vector_db.search(llm_query, top_k=1)
+        if not recommended_list:
+            raise ValueError("VectorDB에서 추천 운동을 찾지 못했습니다.")
+        retrieved_exercise = recommended_list[0]
+        print(f"  > VectorDB 검색 결과 운동명: '{retrieved_exercise['name']}'")
+        return {"recommended_exercise": retrieved_exercise, "search_query": llm_query}
+    except Exception as e:
+        print(f"[RecommendExerciseService] 오류: {e}")
+        return {"error": f"운동 추천 노드 오류: {e}"} 


### PR DESCRIPTION
- Ollama/GPT로 진단 생성 후, 번역 및 GPT 후처리로 자연스러운 한글 소견 제공
- merge 분석에서 5개 부위 점수 중 가장 낮은 점수의 부위만 골라 해당 부위만 진단 생성
- LLM 프롬프트에 “가장 낮은 점수 부위만 개선 대상으로 삼으라”는 규칙 명확히 명시
- 추천운동/검색어 생성 로직을 recommend_exercise_service로 분리, 라우터에서 사용
- ai_coach_service로 AI 코치 메시지 생성 로직 분리, /ai-coach 라우터에서 진단/추천운동을 받아 AI 코치 메시지 생성 및 Redis 세션 관리(24시간, 1인 1세션)