### PR TITLE
feat: add YouTube video support, persistent chat history, and routine management endpoints to chatbot API

### DIFF
--- a/app/ai_coach_router.py
+++ b/app/ai_coach_router.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import redis
 import os
 from dotenv import load_dotenv
@@ -13,10 +13,13 @@ redis_client = redis.Redis(host=os.getenv("REDIS_HOST", "192.168.2.6"), port=637
 router = APIRouter()
 
 class AiCoachRequest(BaseModel):
-    user_id: int
+    user_id: int = Field(..., alias='userId')
     diagnosis: dict
     recommended_exercise: dict
     message: str = None
+
+    class Config:
+        allow_population_by_field_name = True
 
 class AiCoachResponse(BaseModel):
     type: str

--- a/app/youtube_router.py
+++ b/app/youtube_router.py
@@ -3,8 +3,13 @@ from pydantic import BaseModel
 import requests
 import json
 import redis
+import os
+from dotenv import load_dotenv
+from app.graph_workflow import app_youtube_graph
+import time
 
-redis_client = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+load_dotenv()
+redis_client = redis.Redis(host=os.getenv("REDIS_HOST", "192.168.2.6"), port=6379, db=0, decode_responses=True)
 
 router = APIRouter(prefix="/youtube", tags=["YouTube"])
 
@@ -20,56 +25,123 @@ class YoutubeRequest(BaseModel):
 class YoutubeResponse(BaseModel):
     type: str
     response: str
+    sessionId: str = None  # sessionId 필드 추가
     videoUrl: str = None
     videoTitle: str = None
+    youtubeSummary: dict = None
+    commentCount: int = None
+
+    class Config:
+        orm_mode = True
+        allow_population_by_field_name = True
 
 @router.post("", response_model=YoutubeResponse)
 async def youtube_endpoint(req: YoutubeRequest):
-    session_key = f"chat_session:{req.userId}"
-    # SPRING_API_URL 삭제
-    # 진단/추천운동 등은 req에서 직접 받음
-    diagnosis = req.diagnosis or {"korean": "진단 정보가 없습니다."}
-    recommended_exercise = req.recommended_exercise or {"name": "목 스트레칭"}
-    search_query = req.message or ""
-    from app.analyze_router import recommend_exercise_node
-    from app.main_graph import video_search_node, summarize_video_node
-    if req.type == "recommend":
-        state = {
-            "diagnosis": diagnosis,
-            "recommended_exercise": recommended_exercise,
-            "user_message": req.message,
-            "search_query": search_query
-        }
-        result = await video_search_node(state)
-        if "error" in result:
-            return YoutubeResponse(type="error", response=f"영상 추천 오류: {result['error']}")
-        chatbot_result = result.get("chatbot_result", {})
-        video_url = chatbot_result.get("youtube_url")
-        video_title = chatbot_result.get("video_title")
-        redis_client.rpush(session_key, json.dumps({"type": "youtube_recommend", "content": video_url}))
-        return YoutubeResponse(type="youtube_recommend", response="추천 영상입니다.", videoUrl=video_url, videoTitle=video_title)
-    elif req.type == "summary":
-        state = {
-            "diagnosis": diagnosis,
-            "recommended_exercise": recommended_exercise,
-            "user_message": req.message,
-            "search_query": search_query,
-            "chatbot_result": {"youtube_url": req.videoUrl}
-        }
-        result = await summarize_video_node(state)
-        if "error" in result:
-            return YoutubeResponse(type="error", response=f"영상 요약 오류: {result['error']}")
-        summary = result.get("youtube_summary")
-        redis_client.rpush(session_key, json.dumps({"type": "youtube_summary", "content": summary}))
-        return YoutubeResponse(type="youtube_summary", response=str(summary))
-    elif req.type == "comment_summary":
-        from app.agents.youtube_agent import graph as youtube_summary_agent
-        video_url = req.videoUrl
-        summary_result = youtube_summary_agent.invoke({"url": video_url, "reply": "댓글 요약해주세요"})
-        if summary_result.get("error"):
-            return YoutubeResponse(type="error", response=f"댓글 요약 오류: {summary_result['error']}")
-        comment_summary = summary_result.get("comment_summary", {})
-        redis_client.rpush(session_key, json.dumps({"type": "youtube_comment_summary", "content": comment_summary}))
-        return YoutubeResponse(type="youtube_comment_summary", response=str(comment_summary))
-    else:
-        return YoutubeResponse(type="error", response="지원하지 않는 type입니다.") 
+    try:
+        # 요청 타입에 따라 처리
+        if req.type == "recommend":
+            # 운동 추천 후 YouTube 영상 검색 및 요약
+            input_data = {
+                "recommended_exercise": req.recommended_exercise,
+                "diagnosis": req.diagnosis,
+                "search_retries": 0,
+                "tried_video_urls": []
+            }
+            
+            result = app_youtube_graph.invoke(input_data)
+            
+            print(f"[DEBUG] YouTube 그래프 결과: {result}")
+            
+            if "error" in result:
+                raise HTTPException(status_code=400, detail=result["error"])
+            
+            # 결과를 Redis에 저장
+            session_key = f"youtube_session:{req.userId}:{req.historyId}"
+            redis_client.set(session_key, json.dumps(result), ex=60*60*24)
+            
+            # 세션 ID 생성 (기존 세션 ID가 있으면 사용, 없으면 새로 생성)
+            session_id = f"youtube_{req.userId}_{req.historyId}_{int(time.time())}"
+            
+            # 결과에서 필요한 정보 추출
+            chatbot_result = result.get("chatbot_result") or {}
+            video_url = chatbot_result.get("youtube_url") or ""
+            video_title = chatbot_result.get("video_title") or ""
+            youtube_summary = result.get("youtube_summary", {})
+            comment_count = result.get("comment_count")
+            if comment_count is None:
+                comment_count = 0
+            
+            return YoutubeResponse(
+                type="recommend",
+                response="YouTube 영상 추천 완료",
+                sessionId=session_id,  # sessionId 추가
+                videoUrl=video_url,
+                videoTitle=video_title,
+                youtubeSummary=youtube_summary,
+                commentCount=comment_count
+            )
+            
+        elif req.type == "comment_summary":
+            # 댓글 요약만 실행 (댓글 수가 10개 이상일 때만)
+            input_data = {
+                "message": req.message,
+                "videoUrl": req.videoUrl,
+                "recommended_exercise": req.recommended_exercise,
+                "diagnosis": req.diagnosis
+            }
+            
+            # Redis에서 기존 요약 데이터 가져오기
+            session_key = f"youtube_session:{req.userId}:{req.historyId}"
+            if redis_client.exists(session_key):
+                try:
+                    cached_data = json.loads(redis_client.get(session_key))
+                    input_data.update(cached_data)
+                    
+                    # 댓글 수 확인
+                    chatbot_result = cached_data.get("chatbot_result", {})
+                    youtube_summary = cached_data.get("youtube_summary", {})
+                    comment_count = cached_data.get("comment_count", 0)
+                    if comment_count < 10:
+                        return YoutubeResponse(
+                            type="comment_summary",
+                            response="댓글 수가 10개 미만으로 댓글 요약을 제공하지 않습니다.",
+                            sessionId=f"youtube_{req.userId}_{req.historyId}",  # sessionId 추가
+                            videoUrl=chatbot_result.get("youtube_url"),
+                            youtubeSummary=youtube_summary,
+                            commentCount=comment_count
+                        )
+                except Exception:
+                    pass
+            
+            # 댓글 요약 실행
+            from app.graph_workflow import rerun_youtube_agent_node
+            result = rerun_youtube_agent_node(input_data)
+            
+            if "error" in result:
+                raise HTTPException(status_code=400, detail=result["error"])
+            
+            # 결과를 Redis에 저장
+            redis_client.set(session_key, json.dumps(result), ex=60*60*24)
+            
+            # 결과에서 필요한 정보 추출
+            chatbot_result = result.get("chatbot_result", {})
+            youtube_summary = result.get("youtube_summary", {})
+            comment_count = result.get("comment_count", 0)
+            
+            return YoutubeResponse(
+                type="comment_summary",
+                response="댓글 요약 완료",
+                sessionId=f"youtube_{req.userId}_{req.historyId}",  # sessionId 추가
+                videoUrl=chatbot_result.get("youtube_url"),
+                youtubeSummary=youtube_summary,
+                commentCount=comment_count
+            )
+            
+        else:
+            raise HTTPException(status_code=400, detail="지원하지 않는 요청 타입입니다.")
+            
+    except Exception as e:
+        print(f"[ERROR] YouTube 엔드포인트 에러: {str(e)}")
+        import traceback
+        print(f"[ERROR] 상세 에러: {traceback.format_exc()}")
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
- 유투브 영상 챗봇에 띄우기
*유투브 스크립트, 댓글분석은 ip 차단되어서 확인 못함
- ai 코치 대화나 유투브 영상 둘다 이전 대화목록 잘 불러오도록 설정
- 신규루틴 추가, 기존루틴 추가 완료